### PR TITLE
Modified FileList and URLList lambda for LastEvaluatedKey

### DIFF
--- a/lambdas/file_access_patterns/lambda_for_fileList/index.js
+++ b/lambdas/file_access_patterns/lambda_for_fileList/index.js
@@ -22,9 +22,8 @@ function base64ToJson(bString){
 }
   
 exports.listFiles = async (event) =>{
-    try{
-        const reqBody = event.body;
-        const lastEvaluatedKey = base64ToJson(reqBody.LastEvaluatedKey)
+    try{        
+        const lastEvaluatedKey = base64ToJson(event.query.LastEvaluatedKey);
         var params={
             TableName:"V-Transfer",
             ScanIndexForward: false,

--- a/lambdas/url_access_patterns/lambda_for_urlList/index.js
+++ b/lambdas/url_access_patterns/lambda_for_urlList/index.js
@@ -24,7 +24,7 @@ function base64ToJson(bString){
 exports.listUrls = async (event) =>{
     try{
         const reqBody = event.body;
-        const lastEvaluatedKey = base64ToJson(reqBody.LastEvaluatedKey)
+        const lastEvaluatedKey = base64ToJson(event.query.LastEvaluatedKey);
         var params={
             TableName:"V-Transfer",
             ScanIndexForward: false,


### PR DESCRIPTION
# Description
Modifed `lambda_for_fileList` and `lambda_for_URLList` to access LastEvaluatedKey through query parameter instead of request body.

Fixes #59 

## Type of change

Please delete options that are not relevant.

- [X] Updated lambda `@lambda_for_fileList` and `@lambda_for_URLList`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
