### PR TITLE
Changes for URL visibility and clicks_left

### DIFF
--- a/lambdas/url_access_patterns/lambda_for_generateURL/index.js
+++ b/lambdas/url_access_patterns/lambda_for_generateURL/index.js
@@ -28,6 +28,11 @@ exports.generateURL = async (event) => {
   const urlID = generateUniqueId();
   const reqBody = event.body;
   const timestamp = generateTimestamp();
+  var visible=true    //public
+  if(reqBody.visible==="false"||reqBody.visible===false){      
+    visible=false;    //private
+  }
+  var clicks_left=parseInt(reqBody.clicks_left);
   try {
     await dynamo
       .put({
@@ -37,8 +42,8 @@ exports.generateURL = async (event) => {
           SK: `URL#${timestamp}`,
           GS1_PK: `${urlID}`,
           hash: `${reqBody.hash}`,
-          visible: `${reqBody.visible}`,
-          clicks_left: reqBody.clicks_left ? reqBody.clicks_left : 50,
+          visible: visible,
+          clicks_left: clicks_left ? clicks_left : 50,
         },
       })
       .promise();


### PR DESCRIPTION
# Description

- Storing `URL visibility` as boolean in the database irrespective of the datatype of visibility in the request body.
- Storing `clicks_left` as a number in the database irrespective of the datatype of `clicks_left` in the request body.

Fixes #62 

## Type of change

Please delete options that are not relevant.

- [X] Updated lambda `@<lambda_for_generateURL>`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
