### PR TITLE
Resolved query parameter issue

### DIFF
--- a/lambdas/file_access_patterns/lambda_for_fileList/index.js
+++ b/lambdas/file_access_patterns/lambda_for_fileList/index.js
@@ -14,7 +14,7 @@ function jsonToBase64(json_data){
     return encoded;
 }
 function base64ToJson(bString){
-    if (bString === undefined) return bString
+    if (bString === undefined || bString === "undefined" || bString === "null" || bString === "") return undefined
     let decoded = JSON.parse(Buffer.from(bString, 'base64').toString('ascii'));
     return decoded;
 }
@@ -38,7 +38,7 @@ exports.handler = async (event) =>{
             },
             Limit:10,
         }
-        if(searchParam&&searchParam!=="undefined"){
+        if(searchParam && searchParam!=="undefined" && searchParam!=="null" && searchParam!==""){
             params.IndexName="FIND_FILE_BY_NAME";
             params.ExpressionAttributeNames={
               "#PK": "PK",

--- a/lambdas/url_access_patterns/lambda_for_urlList/index.js
+++ b/lambdas/url_access_patterns/lambda_for_urlList/index.js
@@ -17,7 +17,7 @@ function jsonToBase64(json_data){
     return encoded;
 }
 function base64ToJson(bString){
-    if (bString === undefined) return bString
+    if (bString === undefined || bString === "undefined" || bString === "null" || bString === "") return undefined
     let decoded = JSON.parse(Buffer.from(bString, 'base64').toString('ascii'));
     return decoded;
 }


### PR DESCRIPTION
# Description

Resolved query parameter issue for `LastEvaluatedKey` and `SearchParam`.
You can pass `undefined, "undefined", "null", ""` as value to any of the above-mentioned parameter.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Updated lambda `@<Lambda_for_fileList, lambda_for_urlList>`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
