### PR TITLE
Default url on file upload implemented

### DIFF
--- a/lambdas/file_access_patterns/lambda_for_fileUpload/index.js
+++ b/lambdas/file_access_patterns/lambda_for_fileUpload/index.js
@@ -1,8 +1,9 @@
 const AWS = require("aws-sdk");
+const Lambda = new AWS.Lambda()
 const DT = require("date-and-time");
 //AWS.config.loadFromPath("../../../keys.json");
 const dynamo = new AWS.DynamoDB.DocumentClient();
-
+const error_message = 'Internal Server Error';
 function response(statusCode,error, message) {
   return {
     statusCode: statusCode,
@@ -18,6 +19,23 @@ function generateTimestamp() {
   return timestamp;
 }
 
+/**
+ * Returns the stringify payload used for invoking ggenerate url lambda
+ * @param {String} fileHash hash of the file
+ * @param {String} fileId id if file, without FILE# prefix
+ * @returns stringify payload used for invoking ggenerate url lambda
+ */
+function getGenerateUrlPayload(fileHash, fileId) {
+    const payload = {
+        method: "INVOKE",
+        url: `https://mhv71te0rh.execute-api.ap-south-1.amazonaws.com/beta/file/${fileId}/url`,
+        body: { visible: true, hash: fileHash, clicks_left: 50 },
+        query: {},
+        path: { fileId: fileId }
+    }
+    return JSON.stringify(payload)
+}
+
 exports.handler = async (event) => {
   const reqBody = event.body;
   var d = new Date();
@@ -31,31 +49,31 @@ exports.handler = async (event) => {
     f_type: reqBody.f_type,
   };
 
-  try{
-    await dynamo.put({
-      TableName:"V-Transfer",
-      Item: file
-    }).promise()
+  let generateUrlTask;
+  const params = { FunctionName: 'lambda_for_generateURL', InvocationType: 'RequestResponse',
+    Payload: getGenerateUrlPayload(file.hash, file.SK.split('#')[1])
   }
-  catch(err){
-    return response(500,"Internal Server Error",undefined);
+  try {
+    const res = await Lambda.invoke(params).promise()
+    generateUrlTask = JSON.parse(res.Payload)
+} catch(err) { return response(500, error_message, undefined) }
+  file.default = generateUrlTask.Item.GS1_PK
+  const filePutTask = { TableName:"V-Transfer", Item: file }
+  const userMetaDataUpdateTask = { TableName: "V-Transfer",
+    Key: { PK: `USER#${event.path.userId}`, SK: `METADATA` },
+    UpdateExpression: "add storage_used :file_size",
+    ExpressionAttributeValues: { ":file_size": reqBody.size }
   }
 
-  try{
-    await dynamo.update({
-      TableName: "V-Transfer",
-      Key: {
-        PK: `USER#${event.path.userId}`,
-        SK: `METADATA`,
-      },
-      UpdateExpression: "add storage_used :file_size",
-      ExpressionAttributeValues: {
-        ":file_size": reqBody.size,
-      },
-    }).promise()
-    return  response(201, undefined,file)
+  const param = {
+    TransactItems: [{ Put: filePutTask }, { Update: userMetaDataUpdateTask }, { Put: generateUrlTask }]
   }
-  catch(err){
-    return response(500,"Internal Server Error",undefined);
+
+  try {
+    await dynamo.transactWrite(param).promise()
+    return response(200, undefined, file)
+  } catch (err) {
+    return response(500, error_message, undefined)
   }
+
 }

--- a/lambdas/url_access_patterns/lambda_for_generateURL/index.js
+++ b/lambdas/url_access_patterns/lambda_for_generateURL/index.js
@@ -46,6 +46,10 @@ exports.handler = async (event) => {
     TableName: "V-Transfer",
     Item: url,
   }
+  // if event.method is 'INVOKE' then dynamo call is not made and params is returned
+  if(event.method == 'INVOKE') {
+    return params
+  }
   try {
     await dynamo.put(params).promise();
     return response(201, undefined, url);

--- a/lambdas/url_access_patterns/lambda_for_generateURL/package.json
+++ b/lambdas/url_access_patterns/lambda_for_generateURL/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/code-gambit/VT-lambdas#readme",
   "dependencies": {
-    "aws-sdk": "^2.889.0",
     "date-and-time": "^1.0.0",
     "hashids": "^2.2.8"
   }


### PR DESCRIPTION
# Description
Below are the changes:
1. Since file upload includes multiple write request hence query move to `transactWrite`.
2. Added permission for invoking `lambda_for_generateURL`.
3. Modified file schema to include `default: <default URL of file>`.
4. Modified `lambda_for_generateURL` to support the `INVOKE` method. Now it returns the `params` without making the database request when `event.method` is set to `INVOKE`

Fixes #65 

## Type of change

Please delete options that are not relevant.

- [x] Updated lambda `@lambda_for_fileUpload and @lambda_for_generateURL`
- [ ] Created new lambda `@<name of the lambda>`
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
