### PR TITLE
file delete lambda modified to return entire file object after deletion

### DIFF
--- a/lambdas/file_access_patterns/lambda_for_fileDelete/index.js
+++ b/lambdas/file_access_patterns/lambda_for_fileDelete/index.js
@@ -77,7 +77,7 @@ exports.handler = async (event) => {
     var url_data = await dynamo.query(params).promise()
     url_data=url_data.Items;
     if(url_data.length==0){
-      return response(200,undefined,"File delete success")
+      return response(200,undefined,fileData.Attributes)
     }
   }
   catch(err){
@@ -94,7 +94,7 @@ exports.handler = async (event) => {
   //deleting all URL records corresponding to the deleted file record
   try{
     await dynamo.batchWrite(params).promise()
-    return  response(200,undefined,"File delete success")
+    return  response(200,undefined,fileData.Attributes)
   }
   catch(err){
     return response(500,"Internal Server Error",undefined);


### PR DESCRIPTION
# Description
`lambda_for_fileDelete` now returns the entire file object after deletion instead of just a message in response body.

Fixes #72 

## Type of change

Please delete options that are not relevant.

- [x] Updated lambda `@lambda_for_fileDelete`
- [ ] Created new lambda `@<name of the lambda>`
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
